### PR TITLE
@matrixai/events Migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
-        "@matrixai/async-init": "^1.8.4",
+        "@matrixai/async-init": "^1.10.0",
         "@matrixai/contexts": "^1.1.0",
         "@matrixai/errors": "^1.1.7",
+        "@matrixai/events": "^3.2.0",
         "@matrixai/logger": "^3.1.0",
         "@matrixai/table": "^1.2.0",
         "@matrixai/timer": "^1.1.1",
@@ -47,7 +48,7 @@
       },
       "engines": {
         "msvs": "2019",
-        "node": "^18.15.0"
+        "node": ">=19.0.0"
       },
       "optionalDependencies": {
         "@matrixai/mdns-linux-x64": "1.0.5"
@@ -1243,12 +1244,13 @@
       "integrity": "sha512-f0yxu7dHwvffZ++7aCm2WIcCJn18uLcOTdCCwEA3R3KVHYE3TG/JNoTWD9/mqBkAV1AI5vBfJzg27WnF9rOUXQ=="
     },
     "node_modules/@matrixai/async-init": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@matrixai/async-init/-/async-init-1.8.4.tgz",
-      "integrity": "sha512-33cGC7kHTs9KKwMHJA5d5XURWhx3QUq7lLxPEXLoVfWdTHixcWNvtfshAOso0hbRfx1P3ZSgsb+ZHaIASHhWfg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/async-init/-/async-init-1.10.0.tgz",
+      "integrity": "sha512-JjUFu6rqd+dtTHFJ6z8bjbceuFGBj/APWfJByVsfbEH1DJsOgWERFcW3DBUrS0mgTph4Vl518tsNcsSwKT5Y+g==",
       "dependencies": {
         "@matrixai/async-locks": "^4.0.0",
-        "@matrixai/errors": "^1.1.7"
+        "@matrixai/errors": "^1.2.0",
+        "@matrixai/events": "^3.2.0"
       }
     },
     "node_modules/@matrixai/async-locks": {
@@ -1275,17 +1277,37 @@
       }
     },
     "node_modules/@matrixai/errors": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@matrixai/errors/-/errors-1.1.7.tgz",
-      "integrity": "sha512-WD6MrlfgtNSTfXt60lbMgwasS5T7bdRgH4eYSOxV+KWngqlkEij9EoDt5LwdvcMD1yuC33DxPTnH4Xu2XV3nMw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/errors/-/errors-1.2.0.tgz",
+      "integrity": "sha512-eZHPHFla5GFmi0O0yGgbtkca+ZjwpDbMz+60NC3y+DzQq6BMoe4gHmPjDalAHTxyxv0+Q+AWJTuV8Ows+IqBfQ==",
       "dependencies": {
         "ts-custom-error": "3.2.2"
+      }
+    },
+    "node_modules/@matrixai/events": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-MiUr8cUQyGAZCU7EbbMZI1xiYtLnWi/FMSCYpuV+14cMtmU4qfZpCT/nUh+xUNZS3P/LOgR/VjW56BsrJTfICw==",
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@matrixai/logger": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@matrixai/logger/-/logger-3.1.0.tgz",
       "integrity": "sha512-C4JWpgbNik3V99bfGfDell5cH3JULD67eEq9CeXl4rYgsvanF8hhuY84ZYvndPhimt9qjA9/Z8uExKGoiv1zVw=="
+    },
+    "node_modules/@matrixai/mdns-linux-x64": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@matrixai/mdns-linux-x64/-/mdns-linux-x64-1.0.5.tgz",
+      "integrity": "sha512-octXUl11qEQoG+MWzZG0gfy9dknMjdNigPZz3VlObVYdj/1IR88CCeKRJYS0G9YkNI6mPvb8OeZaNxHTsAWXnA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@matrixai/resources": {
       "version": "1.1.5",
@@ -8074,12 +8096,13 @@
       "integrity": "sha512-f0yxu7dHwvffZ++7aCm2WIcCJn18uLcOTdCCwEA3R3KVHYE3TG/JNoTWD9/mqBkAV1AI5vBfJzg27WnF9rOUXQ=="
     },
     "@matrixai/async-init": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@matrixai/async-init/-/async-init-1.8.4.tgz",
-      "integrity": "sha512-33cGC7kHTs9KKwMHJA5d5XURWhx3QUq7lLxPEXLoVfWdTHixcWNvtfshAOso0hbRfx1P3ZSgsb+ZHaIASHhWfg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/async-init/-/async-init-1.10.0.tgz",
+      "integrity": "sha512-JjUFu6rqd+dtTHFJ6z8bjbceuFGBj/APWfJByVsfbEH1DJsOgWERFcW3DBUrS0mgTph4Vl518tsNcsSwKT5Y+g==",
       "requires": {
         "@matrixai/async-locks": "^4.0.0",
-        "@matrixai/errors": "^1.1.7"
+        "@matrixai/errors": "^1.2.0",
+        "@matrixai/events": "^3.2.0"
       }
     },
     "@matrixai/async-locks": {
@@ -8106,17 +8129,28 @@
       }
     },
     "@matrixai/errors": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@matrixai/errors/-/errors-1.1.7.tgz",
-      "integrity": "sha512-WD6MrlfgtNSTfXt60lbMgwasS5T7bdRgH4eYSOxV+KWngqlkEij9EoDt5LwdvcMD1yuC33DxPTnH4Xu2XV3nMw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/errors/-/errors-1.2.0.tgz",
+      "integrity": "sha512-eZHPHFla5GFmi0O0yGgbtkca+ZjwpDbMz+60NC3y+DzQq6BMoe4gHmPjDalAHTxyxv0+Q+AWJTuV8Ows+IqBfQ==",
       "requires": {
         "ts-custom-error": "3.2.2"
       }
+    },
+    "@matrixai/events": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-MiUr8cUQyGAZCU7EbbMZI1xiYtLnWi/FMSCYpuV+14cMtmU4qfZpCT/nUh+xUNZS3P/LOgR/VjW56BsrJTfICw=="
     },
     "@matrixai/logger": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@matrixai/logger/-/logger-3.1.0.tgz",
       "integrity": "sha512-C4JWpgbNik3V99bfGfDell5cH3JULD67eEq9CeXl4rYgsvanF8hhuY84ZYvndPhimt9qjA9/Z8uExKGoiv1zVw=="
+    },
+    "@matrixai/mdns-linux-x64": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@matrixai/mdns-linux-x64/-/mdns-linux-x64-1.0.5.tgz",
+      "integrity": "sha512-octXUl11qEQoG+MWzZG0gfy9dknMjdNigPZz3VlObVYdj/1IR88CCeKRJYS0G9YkNI6mPvb8OeZaNxHTsAWXnA==",
+      "optional": true
     },
     "@matrixai/resources": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
   },
   "dependencies": {
     "@matrixai/async-cancellable": "^1.1.1",
-    "@matrixai/async-init": "^1.8.4",
+    "@matrixai/async-init": "^1.10.0",
     "@matrixai/contexts": "^1.1.0",
     "@matrixai/errors": "^1.1.7",
+    "@matrixai/events": "^3.2.0",
     "@matrixai/logger": "^3.1.0",
     "@matrixai/table": "^1.2.0",
     "@matrixai/timer": "^1.1.1",
@@ -76,7 +77,7 @@
     "typescript": "^4.9.3"
   },
   "engines": {
-    "node": "^18.15.0",
+    "node": ">=19.0.0",
     "msvs": "2019"
   }
 }

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (
-  let rev = "f294325aed382b66c7a188482101b0f336d1d7db"; in
+  let rev = "ea5234e7073d5f44728c499192544a84244bf35a"; in
   builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz"
 )

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
 with pkgs;
 mkShell {
   nativeBuildInputs = [
-    nodejs
+    nodejs_20
     nodejs.python
     shellcheck
     gitAndTools.gh

--- a/src/MDNS.ts
+++ b/src/MDNS.ts
@@ -646,10 +646,7 @@ class MDNS {
     } catch (err) {
       return this.dispatchEvent(
         new events.EventMDNSError({
-          detail: new errors.ErrorMDNSPacketParse(
-            err.message,
-            { cause: err },
-          ),
+          detail: new errors.ErrorMDNSPacketParse(err.message, { cause: err }),
         }),
       );
     }

--- a/src/MDNS.ts
+++ b/src/MDNS.ts
@@ -9,7 +9,6 @@ import type {
   SocketHostRow,
   RemoteInfo,
 } from './types';
-import type { MDNSCacheExpiredEvent } from './cache';
 import type {
   CachableResourceRecord,
   Packet,
@@ -23,6 +22,7 @@ import { PromiseCancellable } from '@matrixai/async-cancellable';
 import { Timer } from '@matrixai/timer';
 import Logger from '@matrixai/logger';
 import Table from '@matrixai/table';
+import { EventResourceRecordCacheExpired } from './cache';
 import {
   generatePacket,
   PacketOpCode,
@@ -388,8 +388,8 @@ class MDNS {
     this.networkRecordCache =
       await ResourceRecordCache.createResourceRecordCache();
     this.networkRecordCache.addEventListener(
-      'expired',
-      (event: MDNSCacheExpiredEvent) =>
+      EventResourceRecordCacheExpired.name,
+      (event: EventResourceRecordCacheExpired) =>
         this.processExpiredResourceRecords(event.detail),
     );
 

--- a/src/cache/ResourceRecordCache.ts
+++ b/src/cache/ResourceRecordCache.ts
@@ -6,12 +6,15 @@ import { Timer } from '@matrixai/timer';
 import Table from '@matrixai/table';
 import canonicalize from 'canonicalize';
 import { QClass, QType, RType } from '@/dns';
-import { MDNSCacheExpiredEvent } from './events';
+import * as events from './events';
 import * as utils from './utils';
 import * as errors from './errors';
 
 interface ResourceRecordCache extends CreateDestroy {}
-@CreateDestroy()
+@CreateDestroy({
+  eventDestroy: events.EventResourceRecordCacheDestroy,
+  eventDestroyed: events.EventResourceRecordCacheDestroyed,
+})
 class ResourceRecordCache extends EventTarget {
   protected resourceRecordCache: Table<CachableResourceRecordRow> = new Table(
     ['name', 'type', 'class', 'data', 'ttl', 'relatedHostname', 'timestamp'],
@@ -299,7 +302,7 @@ class ResourceRecordCache extends EventTarget {
     this.resourceRecordCacheTimer = new Timer(
       async () => {
         this.dispatchEvent(
-          new MDNSCacheExpiredEvent({
+          new events.EventResourceRecordCacheExpired({
             detail: utils.fromCachableResourceRecordRow(record),
           }),
         );

--- a/src/cache/events.ts
+++ b/src/cache/events.ts
@@ -1,15 +1,17 @@
 import type { CachableResourceRecord } from '@/dns';
+import { AbstractEvent } from '@matrixai/events';
 
-class MDNSCacheExpiredEvent extends Event {
-  public detail: CachableResourceRecord;
-  constructor(
-    options: EventInit & {
-      detail: CachableResourceRecord;
-    },
-  ) {
-    super('expired', options);
-    this.detail = options.detail;
-  }
-}
+abstract class EventResourceRecordCache<T = null> extends AbstractEvent<T> {}
 
-export { MDNSCacheExpiredEvent };
+class EventResourceRecordCacheDestroy extends EventResourceRecordCache {}
+
+class EventResourceRecordCacheDestroyed extends EventResourceRecordCache {}
+
+class EventResourceRecordCacheExpired extends EventResourceRecordCache<CachableResourceRecord> {}
+
+export {
+  EventResourceRecordCache,
+  EventResourceRecordCacheDestroy,
+  EventResourceRecordCacheDestroyed,
+  EventResourceRecordCacheExpired,
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,7 +20,6 @@ class ErrorMDNSInterfaceRange<T> extends ErrorMDNS<T> {
   static description = 'MDNS interface range error';
 }
 
-
 class ErrorMDNSPacket<T> extends ErrorMDNS<T> {
   static description = 'DNS Packet error';
 }
@@ -35,7 +34,6 @@ class ErrorMDNSPacketGenerate<T> extends ErrorMDNSPacket<T> {
 class ErrorMDNSSocket<T> extends ErrorMDNS<T> {
   static description = 'MDNS socket error';
 }
-
 
 class ErrorMDNSSocketInternal<T> extends ErrorMDNS<T> {
   static description = 'MDNS socket internal error';
@@ -53,9 +51,7 @@ class ErrorMDNSSocketInvalidReceiveAddress<T> extends ErrorMDNSSocket<T> {
   static description = 'MDNS cannot correctly parse the receive address';
 }
 
-class ErrorMDNSSocketSendFailed<T> extends ErrorMDNSSocket<T> {
-
-}
+class ErrorMDNSSocketSendFailed<T> extends ErrorMDNSSocket<T> {}
 
 export {
   ErrorMDNS,
@@ -71,5 +67,5 @@ export {
   ErrorMDNSSocketInvalidBindAddress,
   ErrorMDNSSocketInvalidSendAddress,
   ErrorMDNSSocketInvalidReceiveAddress,
-  ErrorMDNSSocketSendFailed
+  ErrorMDNSSocketSendFailed,
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,8 +20,25 @@ class ErrorMDNSInterfaceRange<T> extends ErrorMDNS<T> {
   static description = 'MDNS interface range error';
 }
 
+
+class ErrorMDNSPacket<T> extends ErrorMDNS<T> {
+  static description = 'DNS Packet error';
+}
+
+class ErrorMDNSPacketParse<T> extends ErrorMDNSPacket<T> {
+  static description = 'DNS Packet parse error';
+}
+
+class ErrorMDNSPacketGenerate<T> extends ErrorMDNSPacket<T> {
+  static description = 'DNS Packet generation error';
+}
 class ErrorMDNSSocket<T> extends ErrorMDNS<T> {
   static description = 'MDNS socket error';
+}
+
+
+class ErrorMDNSSocketInternal<T> extends ErrorMDNS<T> {
+  static description = 'MDNS socket internal error';
 }
 
 class ErrorMDNSSocketInvalidBindAddress<T> extends ErrorMDNSSocket<T> {
@@ -32,13 +49,27 @@ class ErrorMDNSSocketInvalidSendAddress<T> extends ErrorMDNSSocket<T> {
   static description = 'MDNS cannot send to the specified address';
 }
 
+class ErrorMDNSSocketInvalidReceiveAddress<T> extends ErrorMDNSSocket<T> {
+  static description = 'MDNS cannot correctly parse the receive address';
+}
+
+class ErrorMDNSSocketSendFailed<T> extends ErrorMDNSSocket<T> {
+
+}
+
 export {
   ErrorMDNS,
   ErrorMDNSRunning,
   ErrorMDNSNotRunning,
   ErrorMDNSInterfaceRange,
   ErrorMDNSInvalidMulticastAddress,
+  ErrorMDNSPacket,
+  ErrorMDNSPacketParse,
+  ErrorMDNSPacketGenerate,
   ErrorMDNSSocket,
+  ErrorMDNSSocketInternal,
   ErrorMDNSSocketInvalidBindAddress,
   ErrorMDNSSocketInvalidSendAddress,
+  ErrorMDNSSocketInvalidReceiveAddress,
+  ErrorMDNSSocketSendFailed
 };

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,5 @@
 import type { Service } from './types';
+import { ErrorMDNSPacketParse, ErrorMDNSSocketInternal, ErrorMDNSSocketInvalidReceiveAddress, ErrorMDNSSocketInvalidSendAddress, } from './errors';
 import { AbstractEvent } from '@matrixai/events';
 
 abstract class EventMDNS<T = null> extends AbstractEvent<T> {}
@@ -15,7 +16,12 @@ class EventMDNSService extends EventMDNS<Service> {}
 
 class EventMDNSServiceRemoved extends EventMDNS<Service> {}
 
-class EventMDNSError extends EventMDNS<Error> {}
+class EventMDNSError extends EventMDNS<
+  ErrorMDNSPacketParse<unknown> |
+  ErrorMDNSSocketInternal<unknown> |
+  ErrorMDNSSocketInvalidSendAddress<unknown> |
+  ErrorMDNSSocketInvalidReceiveAddress<unknown>
+> {}
 
 export {
   EventMDNS,

--- a/src/events.ts
+++ b/src/events.ts
@@ -15,6 +15,8 @@ class EventMDNSService extends EventMDNS<Service> {}
 
 class EventMDNSServiceRemoved extends EventMDNS<Service> {}
 
+class EventMDNSError extends EventMDNS<Error> {}
+
 export {
   EventMDNS,
   EventMDNSStart,
@@ -23,4 +25,5 @@ export {
   EventMDNSStopped,
   EventMDNSService,
   EventMDNSServiceRemoved,
+  EventMDNSError,
 };

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,27 +1,26 @@
 import type { Service } from './types';
+import { AbstractEvent } from '@matrixai/events';
 
-class MDNSServiceEvent extends Event {
-  public detail: Service;
-  constructor(
-    options: EventInit & {
-      detail: Service;
-    },
-  ) {
-    super('service', options);
-    this.detail = options.detail;
-  }
-}
+abstract class EventMDNS<T = null> extends AbstractEvent<T> {}
 
-class MDNSServiceRemovedEvent extends Event {
-  public detail: Service;
-  constructor(
-    options: EventInit & {
-      detail: Service;
-    },
-  ) {
-    super('service-removed', options);
-    this.detail = options.detail;
-  }
-}
+class EventMDNSStart extends EventMDNS {}
 
-export { MDNSServiceEvent, MDNSServiceRemovedEvent };
+class EventMDNSStarted extends EventMDNS {}
+
+class EventMDNSStop extends EventMDNS {}
+
+class EventMDNSStopped extends EventMDNS {}
+
+class EventMDNSService extends EventMDNS<Service> {}
+
+class EventMDNSServiceRemoved extends EventMDNS<Service> {}
+
+export {
+  EventMDNS,
+  EventMDNSStart,
+  EventMDNSStarted,
+  EventMDNSStop,
+  EventMDNSStopped,
+  EventMDNSService,
+  EventMDNSServiceRemoved,
+};

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,5 +1,10 @@
 import type { Service } from './types';
-import { ErrorMDNSPacketParse, ErrorMDNSSocketInternal, ErrorMDNSSocketInvalidReceiveAddress, ErrorMDNSSocketInvalidSendAddress, } from './errors';
+import type {
+  ErrorMDNSPacketParse,
+  ErrorMDNSSocketInternal,
+  ErrorMDNSSocketInvalidReceiveAddress,
+  ErrorMDNSSocketInvalidSendAddress,
+} from './errors';
 import { AbstractEvent } from '@matrixai/events';
 
 abstract class EventMDNS<T = null> extends AbstractEvent<T> {}
@@ -17,10 +22,10 @@ class EventMDNSService extends EventMDNS<Service> {}
 class EventMDNSServiceRemoved extends EventMDNS<Service> {}
 
 class EventMDNSError extends EventMDNS<
-  ErrorMDNSPacketParse<unknown> |
-  ErrorMDNSSocketInternal<unknown> |
-  ErrorMDNSSocketInvalidSendAddress<unknown> |
-  ErrorMDNSSocketInvalidReceiveAddress<unknown>
+  | ErrorMDNSPacketParse<unknown>
+  | ErrorMDNSSocketInternal<unknown>
+  | ErrorMDNSSocketInvalidSendAddress<unknown>
+  | ErrorMDNSSocketInvalidReceiveAddress<unknown>
 > {}
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { default as MDNS } from './MDNS';
-export * as types from './types';
+export * from './types';
 export * as utils from './utils';
 export * as errors from './errors';
 export * as events from './events';

--- a/tests/MDNS.test.ts
+++ b/tests/MDNS.test.ts
@@ -1,5 +1,5 @@
-import type { MDNSServiceEvent } from '@/events';
 import type { Hostname, Port } from '@/types';
+import * as events from '@/events';
 import MDNS from '@/MDNS';
 
 describe(MDNS.name, () => {
@@ -28,18 +28,21 @@ describe(MDNS.name, () => {
     } as Parameters<typeof MDNS.prototype.registerService>[0];
     mdns2.registerService(service);
     await new Promise((resolve, reject) => {
-      mdns1.addEventListener('service', (e: MDNSServiceEvent) => {
-        try {
-          expect(e.detail.name).toBe(service.name);
-          expect(e.detail.port).toBe(service.port);
-          expect(e.detail.protocol).toBe(service.protocol);
-          expect(e.detail.type).toBe(service.type);
-          expect(e.detail.hostname).toBe(mdns2Hostname + '.local');
-          resolve(null);
-        } catch (e) {
-          reject(e);
-        }
-      });
+      mdns1.addEventListener(
+        events.EventMDNSService.name,
+        (e: events.EventMDNSService) => {
+          try {
+            expect(e.detail.name).toBe(service.name);
+            expect(e.detail.port).toBe(service.port);
+            expect(e.detail.protocol).toBe(service.protocol);
+            expect(e.detail.type).toBe(service.type);
+            expect(e.detail.hostname).toBe(mdns2Hostname + '.local');
+            resolve(null);
+          } catch (e) {
+            reject(e);
+          }
+        },
+      );
     });
   });
   test('query', async () => {
@@ -66,18 +69,21 @@ describe(MDNS.name, () => {
     mdns2.registerService(service);
     mdns1.startQuery(service);
     await new Promise((resolve, reject) => {
-      mdns1.addEventListener('service', (e: MDNSServiceEvent) => {
-        try {
-          expect(e.detail.name).toBe(service.name);
-          expect(e.detail.port).toBe(service.port);
-          expect(e.detail.protocol).toBe(service.protocol);
-          expect(e.detail.type).toBe(service.type);
-          expect(e.detail.hostname).toBe(mdns2Hostname + '.local');
-          resolve(null);
-        } catch (e) {
-          reject(e);
-        }
-      });
+      mdns1.addEventListener(
+        events.EventMDNSService.name,
+        (e: events.EventMDNSService) => {
+          try {
+            expect(e.detail.name).toBe(service.name);
+            expect(e.detail.port).toBe(service.port);
+            expect(e.detail.protocol).toBe(service.protocol);
+            expect(e.detail.type).toBe(service.type);
+            expect(e.detail.hostname).toBe(mdns2Hostname + '.local');
+            resolve(null);
+          } catch (e) {
+            reject(e);
+          }
+        },
+      );
     });
   });
 });

--- a/tests/cache/ResourceRecordCache.test.ts
+++ b/tests/cache/ResourceRecordCache.test.ts
@@ -1,7 +1,7 @@
 import type { CachableResourceRecord, QuestionRecord } from '@/dns';
-import { EventResourceRecordCacheExpired } from '@/cache/events';
 import type { Host, Hostname } from '@/types';
 import { fc, testProp } from '@fast-check/jest';
+import { EventResourceRecordCacheExpired } from '@/cache/events';
 import { QClass, QType, RClass, RType } from '@/dns';
 import { ResourceRecordCache } from '@/cache';
 import { resourceRecordArb } from '../dns/utils';
@@ -149,17 +149,20 @@ describe(ResourceRecordCache.name, () => {
     await new Promise((resolve, reject) => {
       let expiredIndex = 0;
       const sortedRecords = records.sort((a, b) => a.ttl - b.ttl);
-      cache.addEventListener(EventResourceRecordCacheExpired.name, (event: EventResourceRecordCacheExpired) => {
-        try {
-          expect(event.detail.ttl).toEqual(sortedRecords[expiredIndex].ttl);
-        } catch (e) {
-          reject(e);
-        }
-        if (expiredIndex === sortedRecords.length - 1) {
-          resolve(null);
-        }
-        expiredIndex++;
-      });
+      cache.addEventListener(
+        EventResourceRecordCacheExpired.name,
+        (event: EventResourceRecordCacheExpired) => {
+          try {
+            expect(event.detail.ttl).toEqual(sortedRecords[expiredIndex].ttl);
+          } catch (e) {
+            reject(e);
+          }
+          if (expiredIndex === sortedRecords.length - 1) {
+            resolve(null);
+          }
+          expiredIndex++;
+        },
+      );
     });
   });
 });

--- a/tests/cache/ResourceRecordCache.test.ts
+++ b/tests/cache/ResourceRecordCache.test.ts
@@ -1,5 +1,5 @@
 import type { CachableResourceRecord, QuestionRecord } from '@/dns';
-import type { MDNSCacheExpiredEvent } from '@/cache/events';
+import { EventResourceRecordCacheExpired } from '@/cache/events';
 import type { Host, Hostname } from '@/types';
 import { fc, testProp } from '@fast-check/jest';
 import { QClass, QType, RClass, RType } from '@/dns';
@@ -149,7 +149,7 @@ describe(ResourceRecordCache.name, () => {
     await new Promise((resolve, reject) => {
       let expiredIndex = 0;
       const sortedRecords = records.sort((a, b) => a.ttl - b.ttl);
-      cache.addEventListener('expired', (event: MDNSCacheExpiredEvent) => {
+      cache.addEventListener(EventResourceRecordCacheExpired.name, (event: EventResourceRecordCacheExpired) => {
         try {
           expect(event.detail.ttl).toEqual(sortedRecords[expiredIndex].ttl);
         } catch (e) {


### PR DESCRIPTION
### Description
This PR will migrate the library to take advantage of js-events. Start/stop events will be emitted on instances, and asynchronous tasks and handlers will be cleaned up to have their errors be dispatched as an EventMDNSError. Minor changes will also have to be made to ResourceRecordCache.

API Changes
```
mdns.addEventListener('service') -> mdns.addEventListener(events.EventMDNSService)

mdns.addEventListener('service-removed') -> mdns.addEventListener(events.EventMDNSServiceRemoved)
```

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. @Evented integration
- [x] 2. Upgrade @matrixai/async-init + implement events
- [x] 3. Catch handler error events and dispatch as events
- [x] 4. MDNS cache @Evented integration
- [x] 5. Domain specific errors for EventMDNSError dispatch

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
