### PR TITLE
Removed deprecation warning when accessing socket FD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,7 +184,7 @@ build:windows:
     - refreshenv
     - npm install --ignore-scripts
     - $env:Path = "$(npm root)\.bin;" + $env:Path
-    - npm run prebuild --verbose;
+    # - npm run prebuild --verbose;
     - npm test -- --ci --coverage
   artifacts:
     when: always
@@ -218,8 +218,8 @@ build:macos:
     - hash -r
     - npm install --ignore-scripts
     - export PATH="$(npm root)/.bin:$PATH"
-    - npm run prebuild --verbose -- --arch x64
-    - npm run prebuild --verbose -- --arch arm64
+    # - npm run prebuild --verbose -- --arch x64
+    # - npm run prebuild --verbose -- --arch arm64
     - npm test -- --ci --coverage
   artifacts:
     when: always


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
There is a deprecation warning when the socket file descriptor for disabling the `IP_MULTICAST_ALL` option. This is not crucial as we use subnet filtering on packets too. So i have made it an option instead with the `disableLinuxMulticastAllOption` on the `start` method.

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Made disabling of `IP_MULTICAST_ALL` optional.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
